### PR TITLE
feat: hydrate auth store from session

### DIFF
--- a/wedding-ai-app/src/app/_components/AuthHydrator.tsx
+++ b/wedding-ai-app/src/app/_components/AuthHydrator.tsx
@@ -1,0 +1,32 @@
+"use client";
+
+import { useEffect } from "react";
+import { useSession } from "next-auth/react";
+import { useAuthStore } from "@/store/useAuthStore";
+
+export function AuthHydrator() {
+  const { data: session } = useSession();
+  const setUser = useAuthStore((state) => state.setUser);
+  const updateCredits = useAuthStore((state) => state.updateCredits);
+
+  useEffect(() => {
+    if (session?.user) {
+      const { id, name, email, image, credits } = session.user;
+
+      const authUser = {
+        id,
+        name: name ?? null,
+        email: email ?? null,
+        image: image ?? null,
+        credits: credits ?? 0,
+      };
+
+      setUser(authUser);
+      updateCredits(authUser.credits);
+    } else {
+      setUser(null);
+    }
+  }, [session, setUser, updateCredits]);
+
+  return null;
+}

--- a/wedding-ai-app/src/app/layout.tsx
+++ b/wedding-ai-app/src/app/layout.tsx
@@ -4,6 +4,7 @@ import "./globals.css";
 import { SessionProvider } from "@/app/_components/SessionProvider";
 import { Navigation } from "@/app/_components/Navigation";
 import { ErrorBoundary } from "@/app/_components/ErrorBoundary";
+import { AuthHydrator } from "@/app/_components/AuthHydrator";
 
 const geistSans = Geist({
   variable: "--font-geist-sans",
@@ -33,6 +34,7 @@ export default function RootLayout({
         className={`${geistSans.variable} ${geistMono.variable} antialiased`}
       >
         <SessionProvider>
+          <AuthHydrator />
           <ErrorBoundary>
             <div className="min-h-screen bg-gray-50">
               <Navigation />

--- a/wedding-ai-app/src/store/useAuthStore.ts
+++ b/wedding-ai-app/src/store/useAuthStore.ts
@@ -2,12 +2,19 @@
 
 import { create } from "zustand";
 import { persist } from "zustand/middleware";
-import type { User } from "@/types";
+
+type AuthUser = {
+  id: string;
+  name?: string | null;
+  email?: string | null;
+  image?: string | null;
+  credits: number;
+};
 
 interface AuthState {
-  user: User | null;
+  user: AuthUser | null;
   isLoading: boolean;
-  setUser: (user: User | null) => void;
+  setUser: (user: AuthUser | null) => void;
   setLoading: (loading: boolean) => void;
   updateCredits: (credits: number) => void;
 }


### PR DESCRIPTION
## Summary
- add an AuthHydrator client component that syncs the zustand auth store from NextAuth sessions
- render the hydrator beneath SessionProvider so navigation/upload can immediately access the stored credits
- adjust the auth store types to match session data stored in Zustand

## Testing
- npm run lint *(fails: existing lint warnings/errors in unrelated files)*

------
https://chatgpt.com/codex/tasks/task_e_68c9ea646180832ba79bf79afc6c1328