### PR TITLE
Allow Cloudinary images

### DIFF
--- a/wedding-ai-app/next.config.ts
+++ b/wedding-ai-app/next.config.ts
@@ -1,7 +1,14 @@
 import type { NextConfig } from "next";
 
 const nextConfig: NextConfig = {
-  /* config options here */
+  images: {
+    remotePatterns: [
+      {
+        protocol: "https",
+        hostname: "res.cloudinary.com",
+      },
+    ],
+  },
 };
 
 export default nextConfig;


### PR DESCRIPTION
## Summary
- configure Next.js image optimization to allow Cloudinary-hosted assets

## Testing
- npm run build *(fails: next/font cannot fetch Google Fonts in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_68ca9c91d048832bb2504641f96d2b41