### PR TITLE
Add client directives to interactive UI components

### DIFF
--- a/wedding-ai-app/src/app/_components/ui/Button.tsx
+++ b/wedding-ai-app/src/app/_components/ui/Button.tsx
@@ -1,3 +1,5 @@
+"use client";
+
 import { ButtonHTMLAttributes, forwardRef } from "react";
 import { cn } from "@/lib/utils";
 

--- a/wedding-ai-app/src/app/_components/ui/Card.tsx
+++ b/wedding-ai-app/src/app/_components/ui/Card.tsx
@@ -1,3 +1,5 @@
+"use client";
+
 import { HTMLAttributes, forwardRef } from "react";
 import { cn } from "@/lib/utils";
 

--- a/wedding-ai-app/src/app/_components/ui/Input.tsx
+++ b/wedding-ai-app/src/app/_components/ui/Input.tsx
@@ -1,3 +1,5 @@
+"use client";
+
 import { InputHTMLAttributes, forwardRef } from "react";
 import { cn } from "@/lib/utils";
 

--- a/wedding-ai-app/src/app/_components/ui/LoadingSpinner.tsx
+++ b/wedding-ai-app/src/app/_components/ui/LoadingSpinner.tsx
@@ -1,3 +1,5 @@
+"use client";
+
 import { cn } from "@/lib/utils";
 
 interface LoadingSpinnerProps {


### PR DESCRIPTION
## Summary
- add the required `"use client";` directive to Button, Card, Input, and LoadingSpinner so they continue exporting the same client-side APIs

## Testing
- `npm run build` *(fails: Next.js Turbopack could not fetch the Geist/Geist Mono fonts from Google Fonts in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_68ca9c91d418832b885c7142b74da95b