### PR TITLE
Use next/image for previews and results

### DIFF
--- a/wedding-ai-app/src/app/_components/ImageUpload.tsx
+++ b/wedding-ai-app/src/app/_components/ImageUpload.tsx
@@ -1,6 +1,7 @@
 "use client";
 
-import { useCallback, useState } from "react";
+import Image from "next/image";
+import { useCallback, useEffect, useState } from "react";
 import { useDropzone } from "react-dropzone";
 import { Upload, X, Image as ImageIcon } from "lucide-react";
 import { Button } from "./ui/Button";
@@ -13,7 +14,22 @@ interface ImageUploadProps {
 
 export function ImageUpload({ onUpload }: ImageUploadProps) {
   const [error, setError] = useState<string>("");
+  const [previewUrl, setPreviewUrl] = useState<string | null>(null);
   const { currentImage, setCurrentImage } = useImageStore();
+
+  useEffect(() => {
+    if (!currentImage) {
+      setPreviewUrl(null);
+      return;
+    }
+
+    const objectUrl = URL.createObjectURL(currentImage);
+    setPreviewUrl(objectUrl);
+
+    return () => {
+      URL.revokeObjectURL(objectUrl);
+    };
+  }, [currentImage]);
 
   const onDrop = useCallback(
     (acceptedFiles: File[]) => {
@@ -47,15 +63,20 @@ export function ImageUpload({ onUpload }: ImageUploadProps) {
     setError("");
   };
 
-  if (currentImage) {
+  if (currentImage && previewUrl) {
     return (
       <div className="relative">
         <div className="relative overflow-hidden rounded-lg border-2 border-gray-200">
-          <img
-            src={URL.createObjectURL(currentImage)}
-            alt="업로드된 이미지"
-            className="h-64 w-full object-cover"
-          />
+          <div className="relative h-64 w-full">
+            <Image
+              src={previewUrl}
+              alt="업로드된 이미지"
+              fill
+              className="object-cover"
+              sizes="(min-width: 768px) 512px, 100vw"
+              unoptimized
+            />
+          </div>
           <Button
             variant="ghost"
             size="sm"

--- a/wedding-ai-app/src/app/_components/Navigation.tsx
+++ b/wedding-ai-app/src/app/_components/Navigation.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import Image from "next/image";
 import Link from "next/link";
 import { useSession, signIn, signOut } from "next-auth/react";
 import { Heart, User, CreditCard, LogOut } from "lucide-react";
@@ -62,10 +63,13 @@ export function Navigation() {
                     className="flex items-center space-x-2"
                   >
                     {session.user?.image ? (
-                      <img
+                      <Image
                         src={session.user.image}
                         alt={session.user.name || "사용자"}
-                        className="h-6 w-6 rounded-full"
+                        width={24}
+                        height={24}
+                        className="h-6 w-6 rounded-full object-cover"
+                        unoptimized
                       />
                     ) : (
                       <User className="h-4 w-4" />

--- a/wedding-ai-app/src/app/result/[id]/ResultClient.tsx
+++ b/wedding-ai-app/src/app/result/[id]/ResultClient.tsx
@@ -143,11 +143,14 @@ export function ResultClient({
             <CardDescription>업로드하신 원본 사진입니다</CardDescription>
           </CardHeader>
           <CardContent>
-            <div className="aspect-square overflow-hidden rounded-lg bg-gray-100">
-              <img
+            <div className="relative aspect-square overflow-hidden rounded-lg bg-gray-100">
+              <Image
                 src={generatedImage.originalUrl}
                 alt="원본 사진"
-                className="h-full w-full object-cover"
+                fill
+                className="object-cover"
+                sizes="(min-width: 1024px) 50vw, 100vw"
+                unoptimized
               />
             </div>
           </CardContent>
@@ -162,7 +165,7 @@ export function ResultClient({
             </CardDescription>
           </CardHeader>
           <CardContent>
-            <div className="aspect-square overflow-hidden rounded-lg bg-gray-100">
+            <div className="relative aspect-square overflow-hidden rounded-lg bg-gray-100">
               {generatedImage.status === "PROCESSING" ? (
                 <div className="flex h-full items-center justify-center">
                   <div className="text-center">
@@ -177,10 +180,13 @@ export function ResultClient({
                 </div>
               ) : generatedImage.status === "COMPLETED" &&
                 generatedImage.generatedUrl ? (
-                <img
+                <Image
                   src={generatedImage.generatedUrl}
                   alt="AI 웨딩 사진"
-                  className="h-full w-full object-cover"
+                  fill
+                  className="object-cover"
+                  sizes="(min-width: 1024px) 50vw, 100vw"
+                  unoptimized
                 />
               ) : generatedImage.status === "FAILED" ? (
                 <div className="flex h-full items-center justify-center">


### PR DESCRIPTION
## Summary
- render upload previews with `next/image`, using object URLs and cleanup to avoid leaks
- switch result gallery images to `next/image` while preserving styling and layout
- update navigation avatar rendering to `next/image` so no `<img>` usage remains

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68ca9c933b94832b98881ae14871631a