### PR TITLE
Integrate Stripe payment form into pricing page

### DIFF
--- a/wedding-ai-app/package-lock.json
+++ b/wedding-ai-app/package-lock.json
@@ -12,6 +12,8 @@
         "@google/generative-ai": "^0.21.0",
         "@hookform/resolvers": "^3.3.0",
         "@prisma/client": "^6.0.0",
+        "@stripe/react-stripe-js": "^3.1.0",
+        "@stripe/stripe-js": "^4.1.0",
         "cloudinary": "^2.5.0",
         "clsx": "^2.1.0",
         "framer-motion": "^12.0.0",
@@ -1183,6 +1185,27 @@
       "integrity": "sha512-m2bOd0f2RT9k8QJx1JN85cZYyH1RqFBdlwtkSlf4tBDYLCiiZnv1fIIwacK6cqwXavOydf0NPToMQgpKq+dVlA==",
       "devOptional": true,
       "license": "MIT"
+    },
+    "node_modules/@stripe/react-stripe-js": {
+      "version": "3.10.0",
+      "resolved": "https://registry.npmjs.org/@stripe/react-stripe-js/-/react-stripe-js-3.10.0.tgz",
+      "integrity": "sha512-UPqHZwMwDzGSax0ZI7XlxR3tZSpgIiZdk3CiwjbTK978phwR/fFXeAXQcN/h8wTAjR4ZIAzdlI9DbOqJhuJdeg==",
+      "dependencies": {
+        "prop-types": "^15.7.2"
+      },
+      "peerDependencies": {
+        "@stripe/stripe-js": ">=1.44.1 <8.0.0",
+        "react": ">=16.8.0 <20.0.0",
+        "react-dom": ">=16.8.0 <20.0.0"
+      }
+    },
+    "node_modules/@stripe/stripe-js": {
+      "version": "4.10.0",
+      "resolved": "https://registry.npmjs.org/@stripe/stripe-js/-/stripe-js-4.10.0.tgz",
+      "integrity": "sha512-KrMOL+sH69htCIXCaZ4JluJ35bchuCCznyPyrbN8JXSGQfwBI1SuIEMZNwvy8L8ykj29t6sa5BAAiL7fNoLZ8A==",
+      "engines": {
+        "node": ">=12.16"
+      }
     },
     "node_modules/@swc/helpers": {
       "version": "0.5.15",

--- a/wedding-ai-app/package.json
+++ b/wedding-ai-app/package.json
@@ -26,6 +26,8 @@
     "tailwind-merge": "^2.2.0",
     "@google/generative-ai": "^0.21.0",
     "cloudinary": "^2.5.0",
+    "@stripe/react-stripe-js": "^3.1.0",
+    "@stripe/stripe-js": "^4.1.0",
     "stripe": "^16.0.0",
     "sharp": "^0.33.0"
   },

--- a/wedding-ai-app/src/app/api/payment/create-intent/route.ts
+++ b/wedding-ai-app/src/app/api/payment/create-intent/route.ts
@@ -36,10 +36,22 @@ export async function POST(request: NextRequest) {
       );
     }
 
+    const publishableKey =
+      process.env.STRIPE_PUBLIC_KEY ??
+      process.env.NEXT_PUBLIC_STRIPE_PUBLIC_KEY;
+
+    if (!publishableKey) {
+      return NextResponse.json(
+        { success: false, error: "Stripe 설정이 완료되지 않았습니다." },
+        { status: 500 }
+      );
+    }
+
     return NextResponse.json({
       success: true,
       clientSecret: result.clientSecret,
       paymentIntentId: result.paymentIntentId,
+      publishableKey,
     });
   } catch (error) {
     console.error("Payment intent creation error:", error);


### PR DESCRIPTION
## Summary
- integrate Stripe Elements on the pricing page to render an inline checkout form, surface payment status messaging, and refresh credits after successful payment
- return the publishable key alongside payment intents so the client can initialize Stripe.js safely
- add the Stripe.js client libraries to the project dependencies

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68ca9c943fd0832b9d15ce2025996ab0