### PR TITLE
Fix My Page total spent currency handling

### DIFF
--- a/wedding-ai-app/src/app/my-page/MyPageClient.tsx
+++ b/wedding-ai-app/src/app/my-page/MyPageClient.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState } from "react";
+import { useMemo, useState } from "react";
 import Image from "next/image";
 import Link from "next/link";
 import {
@@ -9,7 +9,6 @@ import {
   Image as ImageIcon,
   ShoppingBag,
   DollarSign,
-  Calendar,
   Settings,
 } from "lucide-react";
 import { Button } from "@/app/_components/ui/Button";
@@ -46,6 +45,15 @@ export function MyPageClient({ user, stats }: MyPageClientProps) {
   const [activeTab, setActiveTab] = useState<
     "overview" | "orders" | "settings"
   >("overview");
+
+  const currencyFormatter = useMemo(
+    () =>
+      new Intl.NumberFormat("en-US", {
+        style: "currency",
+        currency: "USD",
+      }),
+    [],
+  );
 
   const formatDate = (date: Date) => {
     return new Date(date).toLocaleDateString("ko-KR", {
@@ -182,7 +190,7 @@ export function MyPageClient({ user, stats }: MyPageClientProps) {
               </CardHeader>
               <CardContent>
                 <div className="text-2xl font-bold">
-                  ${stats.totalSpent.toFixed(2)}
+                  {currencyFormatter.format(stats.totalSpent)}
                 </div>
                 <p className="text-xs text-muted-foreground">모든 시간</p>
               </CardContent>

--- a/wedding-ai-app/src/app/my-page/page.tsx
+++ b/wedding-ai-app/src/app/my-page/page.tsx
@@ -50,6 +50,7 @@ export default async function MyPage() {
   }
 
   const [totalImages, completedImages, totalOrders, totalSpent] = stats;
+  const totalSpentInDollars = (totalSpent._sum.amount ?? 0) / 100;
 
   return (
     <MyPageClient
@@ -58,7 +59,7 @@ export default async function MyPage() {
         totalImages,
         completedImages,
         totalOrders,
-        totalSpent: totalSpent._sum.amount || 0,
+        totalSpent: totalSpentInDollars,
       }}
     />
   );


### PR DESCRIPTION
## Summary
- convert the aggregated Stripe amount from cents to USD before sending to the client page
- apply an Intl.NumberFormat-based USD currency formatter when rendering the total spent value

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68cab826e730832ba4f0f596303fee82