### PR TITLE
Add loading skeletons to gallery and my page

### DIFF
--- a/wedding-ai-app/src/app/gallery/GalleryClient.tsx
+++ b/wedding-ai-app/src/app/gallery/GalleryClient.tsx
@@ -1,9 +1,9 @@
 "use client";
 
-import { useState } from "react";
+import { useEffect, useState } from "react";
 import Image from "next/image";
 import Link from "next/link";
-import { Download, Share2, Heart, Calendar, Filter } from "lucide-react";
+import { Download, Share2, Calendar, Filter } from "lucide-react";
 import { Button } from "@/app/_components/ui/Button";
 import {
   Card,
@@ -13,6 +13,10 @@ import {
   CardTitle,
 } from "@/app/_components/ui/Card";
 import { GeneratedImage } from "@/types";
+import {
+  GallerySkeleton,
+  Skeleton,
+} from "@/app/_components/LoadingSkeleton";
 
 interface GalleryClientProps {
   images: GeneratedImage[];
@@ -21,6 +25,13 @@ interface GalleryClientProps {
 export function GalleryClient({ images }: GalleryClientProps) {
   const [selectedStyle, setSelectedStyle] = useState<string>("all");
   const [sortBy, setSortBy] = useState<"newest" | "oldest">("newest");
+  const [isLoading, setIsLoading] = useState(true);
+
+  useEffect(() => {
+    if (Array.isArray(images)) {
+      setIsLoading(false);
+    }
+  }, [images]);
 
   // 스타일 필터링
   const filteredImages = images.filter((image) => {
@@ -81,6 +92,18 @@ export function GalleryClient({ images }: GalleryClientProps) {
       alert("링크가 클립보드에 복사되었습니다!");
     }
   };
+
+  if (isLoading) {
+    return (
+      <div className="mx-auto max-w-7xl px-4 py-8 sm:px-6 lg:px-8">
+        <div className="mb-8">
+          <Skeleton className="h-8 w-40 mb-4" />
+          <Skeleton className="h-4 w-64" />
+        </div>
+        <GallerySkeleton />
+      </div>
+    );
+  }
 
   if (images.length === 0) {
     return (

--- a/wedding-ai-app/src/app/my-page/MyPageClient.tsx
+++ b/wedding-ai-app/src/app/my-page/MyPageClient.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState } from "react";
+import { useEffect, useState } from "react";
 import Image from "next/image";
 import Link from "next/link";
 import {
@@ -9,7 +9,6 @@ import {
   Image as ImageIcon,
   ShoppingBag,
   DollarSign,
-  Calendar,
   Settings,
 } from "lucide-react";
 import { Button } from "@/app/_components/ui/Button";
@@ -20,6 +19,11 @@ import {
   CardHeader,
   CardTitle,
 } from "@/app/_components/ui/Card";
+import {
+  CardSkeleton,
+  Skeleton,
+  StatsSkeleton,
+} from "@/app/_components/LoadingSkeleton";
 
 interface User {
   id: string;
@@ -46,6 +50,13 @@ export function MyPageClient({ user, stats }: MyPageClientProps) {
   const [activeTab, setActiveTab] = useState<
     "overview" | "orders" | "settings"
   >("overview");
+  const [isLoading, setIsLoading] = useState(true);
+
+  useEffect(() => {
+    if (user && stats) {
+      setIsLoading(false);
+    }
+  }, [user, stats]);
 
   const formatDate = (date: Date) => {
     return new Date(date).toLocaleDateString("ko-KR", {
@@ -60,6 +71,40 @@ export function MyPageClient({ user, stats }: MyPageClientProps) {
     { id: "orders", label: "주문 내역", icon: ShoppingBag },
     { id: "settings", label: "설정", icon: Settings },
   ] as const;
+
+  if (isLoading) {
+    return (
+      <div className="mx-auto max-w-6xl px-4 py-8 sm:px-6 lg:px-8">
+        <div className="mb-8">
+          <div className="flex items-center gap-4 mb-4">
+            <Skeleton className="h-20 w-20 rounded-full" />
+            <div className="space-y-2 flex-1">
+              <Skeleton className="h-8 w-40" />
+              <Skeleton className="h-4 w-64" />
+              <Skeleton className="h-4 w-32" />
+            </div>
+          </div>
+          <Skeleton className="h-8 w-44 rounded-full" />
+        </div>
+
+        <div className="border-b border-gray-200 mb-8">
+          <div className="-mb-px flex space-x-8">
+            {tabs.map((tab) => (
+              <Skeleton key={tab.id} className="h-9 w-24" />
+            ))}
+          </div>
+        </div>
+
+        <div className="space-y-6">
+          <StatsSkeleton />
+          <div className="grid grid-cols-1 gap-6 lg:grid-cols-2">
+            <CardSkeleton />
+            <CardSkeleton />
+          </div>
+        </div>
+      </div>
+    );
+  }
 
   return (
     <div className="mx-auto max-w-6xl px-4 py-8 sm:px-6 lg:px-8">


### PR DESCRIPTION
## Summary
- add an initial loading flag to gallery client pages and show the gallery skeleton while data hydrates
- add an initial loading state to the my-page client and render header/stats skeleton placeholders before session data is ready

## Testing
- npm run lint *(warns: existing unused exports in src/app/page.tsx and src/types/next-auth.d.ts)*

------
https://chatgpt.com/codex/tasks/task_e_68cab83fee50832b9a0e50f4dbdb1db1